### PR TITLE
extra commma in line 10

### DIFF
--- a/modules/services/api-gateway/variables.tf
+++ b/modules/services/api-gateway/variables.tf
@@ -7,7 +7,7 @@ variable "api_gw_endpoint_configuration_type" {
 }
 
 variable "api_gw_name" {
-  description = "The name of the REST API",
+  description = "The name of the REST API"
 }
 
 variable "stage_name" {


### PR DESCRIPTION
There was a comma at the end of line 10.  possilby by accident, but if left there, tf init fails with 
```
Initializing modules...
- apigw in modules/services/api-gateway
- iam in modules/global/iam
- lambda in modules/services/lambda
- sqs in modules/services/sqs
There are some problems with the configuration, described below.

The Terraform configuration must be valid before initialization so that
Terraform can determine which modules and providers need to be installed.

Error: Unexpected comma after argument

  on modules/services/api-gateway/variables.tf line 10, in variable "api_gw_name":
  10:   description = "The name of the REST API",

Argument definitions must be separated by newlines, not commas. An argument
definition must end with a newline.
```